### PR TITLE
Update URLs (atom-ide-community -> atom-community)

### DIFF
--- a/docs/api/datatip.md
+++ b/docs/api/datatip.md
@@ -9,7 +9,7 @@ links:
   github: https://github.com/atom-community/atom-ide-datatip
 ---
 
-A replacement of the DataTip functionality from atom-ide-ui. When you hover over a symbol in your code (or move your cursor to it), it can show you details about that symbol in a tool tip. [More details](https://github.com/atom-ide-community/atom-ide-datatip#atom-ide-datatip-package)
+A replacement of the DataTip functionality from atom-ide-ui. When you hover over a symbol in your code (or move your cursor to it), it can show you details about that symbol in a tool tip. [More details](https://github.com/atom-community/atom-ide-datatip#atom-ide-datatip-package)
 
 ![screenshot of datatip feature]({{ '/_assets/images/screenshot-datatip.png' | asset | url }})
 

--- a/docs/api/definitions.md
+++ b/docs/api/definitions.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   key: Go to Definition
 links:
   atom: https://atom.io/packages/atom-ide-definitions
-  github: https://github.com/atom-ide-community/atom-ide-definitions#atom-ide-definitions-package
+  github: https://github.com/atom-community/atom-ide-definitions#atom-ide-definitions-package
 ---
 
 A replacement of the go to definition functionality from atom-ide-ui.

--- a/docs/api/sig-help.md
+++ b/docs/api/sig-help.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   key: Signature Help
 links:
   atom: https://atom.io/packages/atom-ide-signature-help
-  github: https://github.com/atom-ide-community/atom-ide-signature-help#atom-ide-signature-help
+  github: https://github.com/atom-community/atom-ide-signature-help#atom-ide-signature-help
 ---
 
 A replacement of the signature help functionality from atom-ide-ui. When you're calling a function, it can help you understand the parameters or information about the function you’re calling. 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -19,6 +19,6 @@ So far, there have been a few features from the original atom-ide-ui package tha
 
 2. Install the [Busy-Signal](https://atom.io/packages/busy-signal) package that is uses by some of the existing ide-packages to show running background tasks
 
-3. Install any of the [community packages](https://atom.io/users/atom-ide-community) listed below.
+3. Install any of the [community packages](https://atom.io/users/atom-community) listed below.
 
 4. Enjoy!

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,4 +82,4 @@ We will start with the most important features, and iterate on them quickly to c
 
 ## Roadmap
 
-We have published our current roadmap on [Github](https://github.com/atom-ide-community/atom-ide-community.github.io/issues/3#issue-424527067) for you to check and provide feedback to us.
+We have published our current roadmap on [Github](https://github.com/atom-community/atom-community.github.io/issues/3#issue-424527067) for you to check and provide feedback to us.


### PR DESCRIPTION
Updates any URLs with `atom-ide-community` to point to the new `atom-community` org instead.

I checked that all these updated links are valid.

All of the GitHub URLs have been automatically redirecting. The one that is meaningfully different is the atom.io profile URL. This one seems to treat `atom-ide-community` and `atom-community` as two separate users/orgs. So the packages which have had their URLs updated in `package.json` show up under https://atom.io/atom-community, whereas packages with the old URL show up at https://atom.io/users/atom-ide-community. I suppose someone should update the URLs in `package.json` for those packages... But that's not actionable strictly within this repo. (This also affects the lack of package owner icon on atom.io and in the Atom settings view. I suppose these services don't follow the GitHub org redirect.)

Thanks for all the work on the docs site BTW.